### PR TITLE
Fix #1 - Zeitreise Flag zensieren

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,4 +12,4 @@
 - **Entworfen am:** 18.12.2023
 - **Empfohlene Punktzahl:** 100
 - **Idee:** Die gesuchte Flag ist schon verschwunden. Nur Zeitreisende können die Challenge lösen.
-- **Flag:** `flag{habe-ich-jetzt-das-internet-gelöscht?}`
+- **Flag:** *\*zensiert*\*


### PR DESCRIPTION
Die Flag für die "Zeitreise" Challenge steht unzensiert in der README.md Datei in diesem Repo.
So kann doch jeder direkt die Challenge lösen, der Zugriff auf dieses öffentliche Repository hat!
Dieser Commit zensiert die Flag.